### PR TITLE
Use `make-variable-like-transformer` from `syntax/transformer`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,6 +5,6 @@
   "A BASIC-Flavored Lisp dialect")
 (define scribblings '(["docs/heresy.scrbl" ()]))
 
-(define deps '("base"))
+(define deps '(("base" #:version "6.2.900.6")))
 (define build-deps '("racket-doc"
                      "rackunit-lib" "sandbox-lib" "scribble-lib"))

--- a/lib/things.rkt
+++ b/lib/things.rkt
@@ -5,7 +5,7 @@
          "require-stuff.rkt"
          (only-in racket/base define-syntax gensym begin let* case-lambda)
          syntax/parse/define
-         (for-syntax racket/base syntax/parse unstable/syntax))
+         (for-syntax racket/base syntax/parse syntax/transformer))
 
 (provide (all-defined-out))
 


### PR DESCRIPTION
That binding is provided by `syntax/transformer` as of 6.2.900.6, and `unstable/syntax` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-lib` package, as it will not be part of the main distribution in future versions.
