### PR TITLE
v0.2.1 hotfix release

### DIFF
--- a/examples/cons-things.rkt
+++ b/examples/cons-things.rkt
@@ -2,9 +2,11 @@
 
 (import rkt racket/base)
 
-(describe Cons
-          (car Null)
-          (cdr Null))
+(describe List)
+(describe Nil extends List)
+(describe Cons extends List
+          (car Nil)
+          (cdr Nil))
 
 (def fn cons (a b)
   (Cons (list a b)))
@@ -18,21 +20,24 @@
 (def fn cons? (v)
   (is-a? Cons v))
 
+(def fn nil? (l)
+  (is-a? Nil l))
+
 (def fn print-cons (l)
   (select
-   ((null? l) "Null")
+   ((nil? l) "Nil")
    ((cons? (car l)) (format$ "Cons(#_, #_)" (print-cons (car l)) (print-cons (cdr l))))
    (else (format$ "Cons(#_, #_)" (car l) (print-cons (cdr l))))))
 
 (def fn cons->list (l)
   (select
-   ((null? l) l)
+   ((nil? l) Null)
    ((cons? (car l)) (join (cons->list (car l))
                         (cons->list (cdr l))))
    (else (join (car l)
                (cons->list (cdr l))))))
 
-(def l (cons 1 (cons (cons 2 (cons 4 Null)) (cons 3 Null))))
+(def l (cons 1 (cons (cons 2 (cons 4 Nil)) (cons 3 Nil))))
 
 (print-cons l)
 (cons->list l)

--- a/examples/hole-test.rkt
+++ b/examples/hole-test.rkt
@@ -10,10 +10,3 @@
 ((deref foo))
 (reset-thing foo (foo 2))
 ((deref foo))
-
-(hole-do
- (a <- (hole 1))
- (b <- (hole 2))
- (z = (+ a b))
- (print z)
- (yield z))

--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define name "Heresy")
 (define collection "heresy")
-(define version "0.2.0")
+(define version "0.2.1")
 (define blurb
   "A BASIC-Flavored Lisp dialect")
 (define scribblings '(["docs/heresy.scrbl" (multi-page) (language)]))


### PR DESCRIPTION
Fixes some bad code leftover in /examples, so that the package will build on pkg.racket-lang.org. 